### PR TITLE
add fixes for videos

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -47,7 +47,7 @@ function App() {
 
     const binaryData = await viamClient.dataClient.binaryDataByFilter(
       filter,
-      100, // limit
+      200, // limit
       VIAM.dataApi.Order.DESCENDING,
       undefined, // no pagination token
       false,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,57 +37,6 @@ function App() {
     hostname,
   } = JSON.parse(Cookies.get(machineInfo)!);
 
-  // Only fetch videos for polling
-  // const fetchVideos = async () => {
-  //   if (!viamClient) return;
-    
-  //   console.log("Fetching videos only for polling");
-
-  //   let filter = {
-  //     robotId: machineId,
-  //   } as VIAM.dataApi.Filter;
-
-  //   const binaryData = await viamClient.dataClient.binaryDataByFilter(
-  //     filter,
-  //     2000, // limit
-  //     VIAM.dataApi.Order.DESCENDING,
-  //     undefined, // no pagination token
-  //     false,
-  //     false,
-  //     false
-  //   );
-    
-  //   // Update files, filtering for videos by extension
-  //   setFiles(prevFiles => {
-  //     // Get existing non-video files
-  //     const existingNonVideoFiles = prevFiles.filter(
-  //       f => !f.metadata?.fileName?.toLowerCase().endsWith('.mp4')
-  //     );
-      
-  //     // Get new video files from the fetched data
-  //     const newVideoFiles = binaryData.data.filter(
-  //       f => f.metadata?.fileName?.toLowerCase().endsWith('.mp4')
-  //     );
-      
-  //     // Combine existing non-video files with new video files
-  //     const existingVideoIds = new Set(prevFiles
-  //       .filter(f => f.metadata?.fileName?.toLowerCase().endsWith('.mp4'))
-  //       .map(f => f.metadata?.binaryDataId)
-  //     );
-      
-  //     const uniqueNewVideos = newVideoFiles.filter(
-  //       f => !existingVideoIds.has(f.metadata?.binaryDataId)
-  //     );
-      
-  //     if (uniqueNewVideos.length > 0) {
-  //       console.log(`Found ${uniqueNewVideos.length} new video files during polling`);
-  //     }
-      
-  //     // Return combined files
-  //     return [...existingNonVideoFiles, ...newVideoFiles];
-  //   });
-  // };
-
   const loadMoreFiles = useCallback(async (passToLoad?: Pass) => {
     // If no pass is specified, use global loading state
     // Otherwise check if this specific pass is already loading

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,14 +13,11 @@ const machineNameRegex = /\/machine\/(.+?)-main\./;
 
 function App() {
   const [passSummaries, setPassSummaries] = useState<Pass[]>([]);
-  const [files, setFiles] = useState<VIAM.dataApi.BinaryData[]>([]);
+  const [files, setFiles] = useState<Map<string, VIAM.dataApi.BinaryData>>(new Map());
   const [videoFiles, setVideoFiles] = useState<Map<string, VIAM.dataApi.BinaryData>>(new Map());
   const [viamClient, setViamClient] = useState<VIAM.ViamClient | null>(null);
   const [robotClient, setRobotClient] = useState<VIAM.RobotClient | null>(null);
-  const [lastFileToken, setLastFileToken] = useState<string | undefined>(undefined);
-  const [hasMoreFiles, setHasMoreFiles] = useState(true);
-  const [isFetchingVideos, setIsFetchingVideos] = useState(false);
-  const [isLoadingFiles, setIsLoadingFiles] = useState(false);
+  const [fetchTimestamp, setFetchTimestamp] = useState<Date | null>(null);
   const [loadingPasses, setLoadingPasses] = useState<Set<string>>(new Set());
 
   const machineNameMatch = window.location.pathname.match(machineNameRegex);
@@ -37,138 +34,14 @@ function App() {
     hostname,
   } = JSON.parse(Cookies.get(machineInfo)!);
 
-  const loadMoreFiles = useCallback(async (passToLoad?: Pass) => {
-    // If no pass is specified, use global loading state
-    // Otherwise check if this specific pass is already loading
-    if (!viamClient || !hasMoreFiles || 
-        (!passToLoad && isLoadingFiles) || 
-        (passToLoad && loadingPasses.has(passToLoad.pass_id))) {
-      return false;
-    }
-
-    // Set appropriate loading state
-    if (passToLoad) {
-      setLoadingPasses(prev => new Set([...prev, passToLoad.pass_id]));
-    } else {
-      setIsLoadingFiles(true);
-    }
-
-    console.log("Loading more files...", passToLoad?.pass_id || "global");
-
-    let filter = {
-      robotId: machineId,
-      mimeType: ["application/octet-stream"],
-    } as VIAM.dataApi.Filter;
-
-    // Add time range filtering if a specific pass is requested
-    if (passToLoad) {
-      // Create proper Timestamp objects
-      const startTimestamp = Timestamp.fromDate(passToLoad.start);
-      
-      // Add 10 minute buffer to end time
-      const endDateWithBuffer = new Date(passToLoad.end.getTime() + 10 * 60 * 1000); // Add 10 minutes in milliseconds
-      const endTimestamp = Timestamp.fromDate(endDateWithBuffer);
-      
-      filter.interval = {
-        start: startTimestamp,
-        end: endTimestamp
-      } as VIAM.dataApi.CaptureInterval;
-      
-      console.log("Filtering for pass time range:", {
-        start: passToLoad.start.toISOString(),
-        end: passToLoad.end.toISOString(),
-        endWithBuffer: endDateWithBuffer.toISOString()
-      });
-    }
-
-    try {
-      let keepFetching = true;
-      let loadedFiles = false;
-      // When filtering by time, start fresh without a pagination token
-      let currentToken = passToLoad ? undefined : lastFileToken;
-      const newFiles: VIAM.dataApi.BinaryData[] = [];
-
-      while (keepFetching) {
-        console.log(`Fetching page with token: ${currentToken}`);
-        const binaryData = await viamClient.dataClient.binaryDataByFilter(
-          filter,
-          50, // limit
-          VIAM.dataApi.Order.DESCENDING,
-          currentToken,
-          false,
-          false,
-          false
-        );
-
-        if (binaryData.data.length > 0) {
-          newFiles.push(...binaryData.data);
-          currentToken = binaryData.last;
-          loadedFiles = true;
-
-          if (passToLoad) {
-            // For pass-specific queries, continue if there's a pagination token
-            if (binaryData.last) {
-              console.log(`Found ${binaryData.data.length} files for pass, continuing to next page...`);
-              keepFetching = true;
-            } else {
-              console.log(`Found ${newFiles.length} total files for the pass`);
-              keepFetching = false;
-            }
-          } else {
-            // For general queries, stop after one page
-            keepFetching = false;
-          }
-        } else {
-          console.log("No more data from API.");
-          keepFetching = false;
-        }
-
-        if (!binaryData.last) {
-          console.log("No more pages to fetch.");
-          // Only update hasMoreFiles if we're not doing a pass-specific query
-          if (!passToLoad) {
-            setHasMoreFiles(false);
-          }
-          keepFetching = false;
-        }
-      }
-
-      // Update the global state once, after the loop is complete
-      if (newFiles.length > 0) {
-        setFiles(prevFiles => [...prevFiles, ...newFiles]);
-        // Only update the token if we're not doing a pass-specific query
-        if (!passToLoad) {
-          setLastFileToken(currentToken);
-        }
-      }
-
-      loadedFiles = newFiles.length > 0;
-      return loadedFiles;
-    } catch (error) {
-      console.error("Failed to load more files:", error);
-      return false;
-    } finally {
-      // Clear the appropriate loading state
-      if (passToLoad) {
-        setLoadingPasses(prev => {
-          const next = new Set(prev);
-          next.delete(passToLoad.pass_id);
-          return next;
-        });
-      } else {
-        setIsLoadingFiles(false);
-      }
-    }
-  }, [viamClient, hasMoreFiles, isLoadingFiles, lastFileToken, machineId, loadingPasses]);
-
-  const fetchVideos = async (start: Date, shouldSetLoadingState: boolean = true) => {
+  const fetchFiles = async (start: Date, shouldSetLoadingState: boolean = true) => {
     if (!viamClient) return;
 
     const end = new Date();
     
-    console.log("Fetching videos for time range:", start, end);
+    console.log("Fetching for time range:", start, end);
     if (shouldSetLoadingState) {
-      setIsFetchingVideos(true);
+      setFetchTimestamp(start);
     }
 
     let filter = {
@@ -177,69 +50,72 @@ function App() {
         start: Timestamp.fromDate(start),
         end: Timestamp.fromDate(end),
       } as VIAM.dataApi.CaptureInterval,
-      mimeType: ["application/octet-stream"],
     } as VIAM.dataApi.Filter;
 
-    let binaryData = await viamClient.dataClient.binaryDataByFilter(
-      filter,
-      100, // limit
-      VIAM.dataApi.Order.DESCENDING,
-      undefined, // no pagination token
-      false,
-      false,
-      false
-    );
-    // Filter for .mp4 files and add to Set
-    console.log("Raw binary data count:", binaryData.data.length);
-    // console.log("All filenames from first batch:", binaryData.data.map(file => file.metadata?.fileName));
-    
-    setVideoFiles(prevVideoFiles => {
-      const newVideoFiles = new Map(prevVideoFiles);
-      binaryData.data
-        .filter(file => file.metadata?.fileName?.toLowerCase().includes('.mp4'))
-        .forEach(file => {
-          if (file.metadata?.binaryDataId) {
-            newVideoFiles.set(file.metadata.binaryDataId, file);
-          }
-        });
-      console.log("Filtered video files count:", newVideoFiles.size);
-      return newVideoFiles;
-    });
+    let paginationToken: string | undefined = undefined;
 
-
-    while (binaryData.last) {
-      binaryData = await viamClient.dataClient.binaryDataByFilter(
+    // Process files in batches using a while loop to eliminate code duplication
+    while (true) {
+      let binaryData = await viamClient.dataClient.binaryDataByFilter(
         filter,
         100, // limit
         VIAM.dataApi.Order.DESCENDING,
-        binaryData.last,
+        paginationToken,
         false,
         false,
         false
       );
       
-      // Filter new data for .mp4 files and add to Set
-      console.log(`Additional batch count: ${binaryData.data.length}`);
+      // Process files once and build both files and videoFiles lists
+      const newFiles = new Map<string, VIAM.dataApi.BinaryData>();
+      const newVideoFiles = new Map<string, VIAM.dataApi.BinaryData>();
+      
+      binaryData.data.forEach(file => {
+        if (file.metadata?.binaryDataId) {
+          if (file.metadata.fileName?.toLowerCase().includes('.mp4')) {
+            // Video files go to videoFiles
+            newVideoFiles.set(file.metadata.binaryDataId, file);
+          } else {
+            // Non-video files go to files
+            newFiles.set(file.metadata.binaryDataId, file);
+          }
+        }
+      });
+
+      paginationToken = binaryData.last;
+
+      if (binaryData.data.length > 0 && shouldSetLoadingState) {
+        setFetchTimestamp(binaryData.data[binaryData.data.length - 1].metadata!.timeRequested!.toDate());
+      }
+      
+      // Update both states with the processed files
+      setFiles(prevFiles => {
+        const updatedFiles = new Map(prevFiles);
+        newFiles.forEach((file, id) => {
+          updatedFiles.set(id, file);
+        });
+        return updatedFiles;
+      });
       
       setVideoFiles(prevVideoFiles => {
-        const newVideoFiles = new Map(prevVideoFiles);
-        binaryData.data
-          .filter(file => file.metadata?.fileName?.toLowerCase().includes('.mp4'))
-          .forEach(file => {
-            if (file.metadata?.binaryDataId) {
-              newVideoFiles.set(file.metadata.binaryDataId, file);
-            }
-          });
-        console.log(`Total video files after this batch: ${newVideoFiles.size}`);
-        return newVideoFiles;
+        const updatedVideoFiles = new Map(prevVideoFiles);
+        newVideoFiles.forEach((file, id) => {
+          updatedVideoFiles.set(id, file);
+        });
+        return updatedVideoFiles;
       });
+      
+      // Break if no more data to fetch
+      if (!binaryData.last) break;
     }
+    console.log("total files count:", files.size);
+    console.log("total video files count:", videoFiles.size);
     
-    setIsFetchingVideos(false);
+    setFetchTimestamp(null)
   };
 
   useEffect(() => {
-    const fetchData = async () => {
+    const fetchPasses = async () => {
       console.log("Fetching data start");
 
       const viamClient = await connect(apiKeyId, apiKeySecret);
@@ -312,14 +188,15 @@ function App() {
       console.log("Fetching data end");
     };
     
-      fetchData();
+      fetchPasses();
     }, [apiKeyId, apiKeySecret, hostname, machineId, locationId]);
+
 
   // Fetch videos when passSummaries and viamClient are available
   useEffect(() => {
     if (passSummaries.length > 0 && viamClient) {
-      const earliestVideoTime = passSummaries[passSummaries.length - 1].end;
-      fetchVideos(earliestVideoTime);
+      const earliestVideoTime = passSummaries[passSummaries.length - 1].start;
+      fetchFiles(earliestVideoTime);
     }
   }, [passSummaries, viamClient]);
 
@@ -331,12 +208,9 @@ function App() {
       files={files}
       videoFiles={videoFiles}
       robotClient={robotClient}
-      fetchVideos={fetchVideos}
-      loadMoreFiles={loadMoreFiles}
-      hasMoreFiles={hasMoreFiles}
-      isLoadingFiles={isLoadingFiles}
-      isFetchingVideos={isFetchingVideos}
+      fetchVideos={fetchFiles}
       loadingPasses={loadingPasses}
+      fetchTimestamp={fetchTimestamp}
     />
   );
 }

--- a/src/AppInterface.tsx
+++ b/src/AppInterface.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect, useMemo, useCallback } from 'react';
 import * as VIAM from "@viamrobotics/sdk";
 import './AppInterface.css';
 import StepVideosGrid from './StepVideosGrid';
@@ -53,10 +53,12 @@ const AppInterface: React.FC<AppViewProps> = ({
   const [videoStoreClient, setVideoStoreClient] = useState<VIAM.GenericComponentClient | null>(null);
   const [loadingRows, setLoadingRows] = useState<Set<number>>(new Set());
 
-  // Filter files to only include video files (.mp4)
-  const videoFiles = files.filter((file: VIAM.dataApi.BinaryData) => 
-    file.metadata?.fileName?.toLowerCase().endsWith('.mp4')
-  );
+  // Filter files to only include video files (.mp4) - recalculated whenever files changes
+  const videoFiles = useMemo(() => {
+    return files.filter((file: VIAM.dataApi.BinaryData) => 
+      file.metadata?.fileName?.toLowerCase().endsWith('.mp4')
+    );
+  }, [files]);
 
   const activeTabStyle = "bg-blue-600 text-white";
   const inactiveTabStyle = "bg-gray-200 text-gray-700 hover:bg-gray-300";
@@ -75,6 +77,8 @@ const AppInterface: React.FC<AppViewProps> = ({
         // Set loading state for this specific row
         setLoadingRows(prev => new Set(prev).add(index));
         await loadMoreFiles(pass);
+        // Also fetch videos when expanding a row
+        await fetchVideos();
         setLoadingRows(prev => {
           const newSet = new Set(prev);
           newSet.delete(index);
@@ -87,7 +91,7 @@ const AppInterface: React.FC<AppViewProps> = ({
     }
   };
 
-  const getStepVideos = (step: Step) => {
+  const getStepVideos = useCallback((step: Step) => {
     if (!videoFiles) return [];
 
     return videoFiles.filter(file => {
@@ -95,7 +99,7 @@ const AppInterface: React.FC<AppViewProps> = ({
       const isMatchingStep = file.metadata.fileName.includes(step.pass_id) && file.metadata.fileName.includes(step.name)
       return isMatchingStep
     });
-  };
+  }, [videoFiles]);
 
   const getStatusBadge = (success: boolean) => {
     if (success) {

--- a/src/AppInterface.tsx
+++ b/src/AppInterface.tsx
@@ -57,13 +57,6 @@ const AppInterface: React.FC<AppViewProps> = ({
   const [videoStoreClient, setVideoStoreClient] = useState<VIAM.GenericComponentClient | null>(null);
   const [loadingRows, setLoadingRows] = useState<Set<number>>(new Set());
 
-  // Filter files to only include video files (.mp4) - recalculated whenever files changes
-  // const videoFiles = useMemo(() => {
-  //   return files.filter((file: VIAM.dataApi.BinaryData) => 
-  //     file.metadata?.fileName?.toLowerCase().endsWith('.mp4')
-  //   );
-  // }, [files]);
-
   const activeTabStyle = "bg-blue-600 text-white";
   const inactiveTabStyle = "bg-gray-200 text-gray-700 hover:bg-gray-300";
 
@@ -81,7 +74,6 @@ const AppInterface: React.FC<AppViewProps> = ({
         // Set loading state for this specific row
         setLoadingRows(prev => new Set(prev).add(index));
         await loadMoreFiles(pass);
-        // Also fetch videos when expanding a row
         setLoadingRows(prev => {
           const newSet = new Set(prev);
           newSet.delete(index);
@@ -94,7 +86,7 @@ const AppInterface: React.FC<AppViewProps> = ({
     }
   };
 
-  const getStepVideos = useCallback((step: Step) => {
+  const getStepVideos = (step: Step) => {
     if (!videoFiles || videoFiles.size === 0) return [];
     
     let stepVideos: VIAM.dataApi.BinaryData[] = [];
@@ -111,7 +103,7 @@ const AppInterface: React.FC<AppViewProps> = ({
     });
 
     return stepVideos;
-  }, [videoFiles]);
+  };
 
   const getStatusBadge = (success: boolean) => {
     if (success) {

--- a/src/AppInterface.tsx
+++ b/src/AppInterface.tsx
@@ -94,10 +94,28 @@ const AppInterface: React.FC<AppViewProps> = ({
   const getStepVideos = useCallback((step: Step) => {
     if (!videoFiles) return [];
 
-    return videoFiles.filter(file => {
-      if (!file.metadata || !file.metadata.fileName) return false;
-      const isMatchingStep = file.metadata.fileName.includes(step.pass_id) && file.metadata.fileName.includes(step.name)
-      return isMatchingStep
+    // Create a map to track unique videos by their binary ID
+    const uniqueVideos = new Map<string, VIAM.dataApi.BinaryData>();
+    
+    videoFiles.forEach(file => {
+      if (!file.metadata || !file.metadata.fileName) return;
+      
+      const isMatchingStep = file.metadata.fileName.includes(step.pass_id) && 
+                           file.metadata.fileName.includes(step.name);
+      
+      if (isMatchingStep && file.metadata.binaryDataId) {
+        // Only add if we haven't seen this ID before
+        if (!uniqueVideos.has(file.metadata.binaryDataId)) {
+          uniqueVideos.set(file.metadata.binaryDataId, file);
+        }
+      }
+    });
+    
+    // Return array of unique videos sorted by time
+    return Array.from(uniqueVideos.values()).sort((a, b) => {
+      const timeA = a.metadata?.timeRequested?.toDate().getTime() || 0;
+      const timeB = b.metadata?.timeRequested?.toDate().getTime() || 0;
+      return timeA - timeB;
     });
   }, [videoFiles]);
 

--- a/src/StepVideosGrid.tsx
+++ b/src/StepVideosGrid.tsx
@@ -68,11 +68,6 @@ const StepVideosGrid: React.FC<StepVideosGridProps> = ({
     };
   }, []);
 
-  // useEffect(() => {
-  //   console.log("stepVideos", stepVideos);
-  // }, [stepVideos]);
-
-
   const handleVideoClick = (video: VIAM.dataApi.BinaryData) => {
     setSelectedVideo(video);
   };

--- a/src/StepVideosGrid.tsx
+++ b/src/StepVideosGrid.tsx
@@ -14,7 +14,7 @@ interface StepVideosGridProps {
   viamClient: VIAM.ViamClient;
   step: Step;
   fetchVideos: (start: Date, shouldSetLoadingState: boolean) => Promise<void>;
-  isFetchingVideos: boolean;
+  fetchTimestamp: Date | null;
 }
 
 const StepVideosGrid: React.FC<StepVideosGridProps> = ({
@@ -24,7 +24,7 @@ const StepVideosGrid: React.FC<StepVideosGridProps> = ({
   viamClient,
   step,
   fetchVideos,
-  isFetchingVideos,
+  fetchTimestamp,
 }) => {
   const [selectedVideo, setSelectedVideo] =
     useState<VIAM.dataApi.BinaryData | null>(null);
@@ -105,7 +105,7 @@ const StepVideosGrid: React.FC<StepVideosGridProps> = ({
     }
   };
 
-  if (stepVideos.length === 0 && isFetchingVideos) {
+  if (stepVideos.length === 0 && fetchTimestamp && fetchTimestamp > step.start) {
     return (
       <div className="loading-state" style={{
         display: 'flex',


### PR DESCRIPTION
This PR fixes video loading behaviour that was broken when we switch to per pass file fetching. The approach here is that we:
1. kick off a diff binary data by filter call from the earliest pass time to now
2. As we loop over this, build a list of video files and pass those files to the step videos grid
3. While this iteration is going if a step doesnt have a video AND we're still fetching, show a loading icon
4. Once 1 video is found per step, show the video and hide the loading icon

Tested manually, video generation and polling still works and updates the grid as expected